### PR TITLE
Add: bypassAuth config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *.0x/
 docs/jsdoc/
 .DS_Store
+temp

--- a/secrets.default.jsonc
+++ b/secrets.default.jsonc
@@ -11,7 +11,7 @@
         // the IP address or URL of your mongodb instance
         "address": "mongodb.example.com",
         // Used to access a database without credentials
-        "bypassAuth": "false",
+        "bypassAuth": false,
         // authentication credentials
         "username": "YOUR_MONGO_USERNAME",
         "password": "YOUR_MONGO_PASSWORD",

--- a/secrets.default.jsonc
+++ b/secrets.default.jsonc
@@ -10,9 +10,12 @@
         "protocol": "mongodb://",
         // the IP address or URL of your mongodb instance
         "address": "mongodb.example.com",
+        // Used to access a database without credentials
+        "localDB": "false",
         // authentication credentials
         "username": "YOUR_MONGO_USERNAME",
-        "password": "YOUR_MONGO_PASSWORD"
+        "password": "YOUR_MONGO_PASSWORD",
+        "dbName": "turingbot"
     },
     // these credentials are shared between the google and youtube modules.
     "google": {

--- a/secrets.default.jsonc
+++ b/secrets.default.jsonc
@@ -11,7 +11,7 @@
         // the IP address or URL of your mongodb instance
         "address": "mongodb.example.com",
         // Used to access a database without credentials
-        "localDB": "false",
+        "bypassAuth": "false",
         // authentication credentials
         "username": "YOUR_MONGO_USERNAME",
         "password": "YOUR_MONGO_PASSWORD",

--- a/src/core/mongo.ts
+++ b/src/core/mongo.ts
@@ -12,11 +12,27 @@ import {Dependency} from './modules.js';
  */
 export const mongo = new Dependency('MongoDB', async () => {
   const mongoConfig = botConfig.secrets.mongodb;
-  // https://www.mongodb.com/docs/manual/reference/connection-string/
-  const connectionString =
-    `${mongoConfig.protocol}${mongoConfig.username}:${mongoConfig.password}` +
-    `@${mongoConfig.address}:27017`;
 
+  let localDB = `${mongoConfig.localDB}`
+  const test : boolean = localDB.toLowerCase() === 'true'
+
+  if (test) {
+    // https://www.mongodb.com/docs/manual/reference/connection-string/
+    const connectionString =
+      `${mongoConfig.protocol}${mongoConfig.username}:${mongoConfig.password}` +
+    `@${mongoConfig.address}:27017`;
+  } else {
+    // https://www.mongodb.com/docs/manual/reference/connection-string/
+    const connectionString =
+      `${mongoConfig.protocol}` +
+      `${mongoConfig.address}:27017`;
+  };
+
+  //TODO: remove this
+  console.log(connectionString)
+  console.log(`${mongoConfig.localDB}`)
+  console.log(test)
+  
   // https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/#std-label-node-connect-to-mongodb
   const mongoClient = new MongoClient(connectionString, {
     serverApi: {
@@ -31,5 +47,5 @@ export const mongo = new Dependency('MongoDB', async () => {
     throw err;
   });
 
-  return mongoClient.db('turingbot');
+  return mongoClient.db(`${mongoConfig.dbName}`);
 });

--- a/src/core/mongo.ts
+++ b/src/core/mongo.ts
@@ -30,11 +30,6 @@ export const mongo = new Dependency('MongoDB', async () => {
   if (typeof mongoConfig.bypassAuth !== 'boolean') {
     throw new Error("bypassAuth is not a boolean")
   }
-
-  //TODO: remove this
-  console.log('connectionString: '+connectionString)
-  console.log('bypassAuth: '+`${mongoConfig.bypassAuth}`)
-  console.log('bypassAuth Type: '+typeof mongoConfig.bypassAuth);
   
   // https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/#std-label-node-connect-to-mongodb
   const mongoClient = new MongoClient(connectionString, {

--- a/src/core/mongo.ts
+++ b/src/core/mongo.ts
@@ -13,8 +13,8 @@ import {Dependency} from './modules.js';
 export const mongo = new Dependency('MongoDB', async () => {
   const mongoConfig = botConfig.secrets.mongodb;
 
-  let localDB = `${mongoConfig.localDB}`
-  const test : boolean = localDB.toLowerCase() === 'true'
+  let bypassAuth = `${mongoConfig.bypassAuth}`
+  const test : boolean = bypassAuth.toLowerCase() === 'true'
 
   if (test) {
     // https://www.mongodb.com/docs/manual/reference/connection-string/
@@ -22,7 +22,6 @@ export const mongo = new Dependency('MongoDB', async () => {
       `${mongoConfig.protocol}${mongoConfig.username}:${mongoConfig.password}` +
     `@${mongoConfig.address}:27017`;
   } else {
-    // https://www.mongodb.com/docs/manual/reference/connection-string/
     const connectionString =
       `${mongoConfig.protocol}` +
       `${mongoConfig.address}:27017`;
@@ -30,7 +29,7 @@ export const mongo = new Dependency('MongoDB', async () => {
 
   //TODO: remove this
   console.log(connectionString)
-  console.log(`${mongoConfig.localDB}`)
+  console.log(`${mongoConfig.bypassAuth}`)
   console.log(test)
   
   // https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/#std-label-node-connect-to-mongodb

--- a/src/core/mongo.ts
+++ b/src/core/mongo.ts
@@ -13,24 +13,24 @@ import {Dependency} from './modules.js';
 export const mongo = new Dependency('MongoDB', async () => {
   const mongoConfig = botConfig.secrets.mongodb;
 
-  let bypassAuth = `${mongoConfig.bypassAuth}`
-  const test : boolean = bypassAuth.toLowerCase() === 'true'
-
-  if (test) {
-    // https://www.mongodb.com/docs/manual/reference/connection-string/
-    const connectionString =
-      `${mongoConfig.protocol}${mongoConfig.username}:${mongoConfig.password}` +
-    `@${mongoConfig.address}:27017`;
-  } else {
-    const connectionString =
+  let connectionString = "placeholder value"
+  if (`${mongoConfig.bypassAuth}`) {
+    connectionString =
       `${mongoConfig.protocol}` +
       `${mongoConfig.address}:27017`;
-  };
+  }
+
+  if (!`${mongoConfig.bypassAuth}`) {
+    // https://www.mongodb.com/docs/manual/reference/connection-string/
+    connectionString =
+      `${mongoConfig.protocol}${mongoConfig.username}:${mongoConfig.password}` +
+    `@${mongoConfig.address}:27017`;
+  } 
 
   //TODO: remove this
-  console.log(connectionString)
-  console.log(`${mongoConfig.bypassAuth}`)
-  console.log(test)
+  console.log('connectionString: '+connectionString)
+  console.log('bypassAuth: '+`${mongoConfig.bypassAuth}`)
+  console.log('bypassAuth Type: '+typeof mongoConfig.bypassAuth);
   
   // https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/#std-label-node-connect-to-mongodb
   const mongoClient = new MongoClient(connectionString, {

--- a/src/core/mongo.ts
+++ b/src/core/mongo.ts
@@ -20,12 +20,16 @@ export const mongo = new Dependency('MongoDB', async () => {
       `${mongoConfig.address}:27017`;
   }
 
-  if (!`${mongoConfig.bypassAuth}`) {
+  if (!mongoConfig.bypassAuth) {
     // https://www.mongodb.com/docs/manual/reference/connection-string/
     connectionString =
       `${mongoConfig.protocol}${mongoConfig.username}:${mongoConfig.password}` +
     `@${mongoConfig.address}:27017`;
-  } 
+  }
+
+  if (typeof mongoConfig.bypassAuth !== 'boolean') {
+    throw new Error("bypassAuth is not a boolean")
+  }
 
   //TODO: remove this
   console.log('connectionString: '+connectionString)


### PR DESCRIPTION
Added a bypassAuth config flag so that users can easily do local development tests or otherwise sync to databases without authentication.

Also made the database name a config flag and not hard-coded, default value is the old hardcoded one.